### PR TITLE
Add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,166 @@
+# Changelog
+
+All notable changes to `likeminds-feed-android`, generated from its GitHub Releases.
+
+Full release history: https://github.com/LikeMindsCommunity/likeminds-feed-android/releases
+
+---
+
+## [1.8.0] - 2025-05-02
+
+### What's Changed
+* Release v1.8.0 by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/54
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.7.0...v1.8.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.8.0)
+
+## [1.7.0] - 2025-01-28
+
+### What's Changed
+* Release v1.7.0 by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/52
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.6.0...v1.7.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.7.0)
+
+## [1.6.0] - 2025-01-03
+
+### What's Changed
+* Release v1.6.0 by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/50
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.5.1...v1.6.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.6.0)
+
+## [1.5.1] - 2024-12-24
+
+### What's Changed
+* Release v1.5.0 by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/47
+* [Hotfix/LM-13142] Crash in Social Feed by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/48
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.4.0...v1.5.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.5.1)
+
+## [1.4.0] - 2024-10-21
+
+### What's Changed
+* [LM-12922] Fixed Video Fragment Lifecycle issues by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/43
+* Release v1.4.0 by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/44
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.3.3...v1.4.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.4.0)
+
+## [1.3.3] - 2024-10-03
+
+### What's Changed
+* [LM-12873] Video doesn't pause when fragment is hidden by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/42
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.3.2...v1.3.3
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.3.3)
+
+## [1.3.2] - 2024-09-09
+
+### What's Changed
+* [Hotfix][LM-12746] Removed Dummy Data for Custom Widget by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/38
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.3.1...v1.3.2
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.3.2)
+
+## [1.3.1] - 2024-08-13
+
+### What's Changed
+* [Hotfix/LM-12650] Add Refresh Support in Video Feed by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/36
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.3.0...v1.3.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.3.1)
+
+## [1.3.0] - 2024-08-13
+
+### What's Changed
+* Release v1.3.0 by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/34
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.2.0...v1.3.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.3.0)
+
+## [1.2.0] - 2024-08-09
+
+### What's Changed
+* [LM-10922] Added API Key Security by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/28
+* Release v1.2.0 by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/29
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.1.1...v1.2.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.2.0)
+
+## [1.1.1] - 2024-06-13
+
+### What's Changed
+* [Hotfix][LM12103] Fixed Create Post Rights Issues. by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/27
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.1.0...v1.1.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.1.1)
+
+## [1.1.0] - 2024-06-06
+
+### What's Changed
+* [LM-11138] Changes as per Changes in Data Layer by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/18
+* [LM-11139] LMPostPoll Widget by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/19
+* [LM-11140] Poll Results by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/20
+* [LM-11142] Display of Poll by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/22
+* [LM-11141] Added Create Poll Flow by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/21
+* [LM-11416] Product Signoff bugs: Poll in Feed by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/23
+* [LM-10972] Poll in Feed by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/25
+* [Bugfix] LMOlympics  Bugfix by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/24
+* Release v1.1.0 by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/26
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/compare/v1.0.0...v1.1.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.1.0)
+
+## [1.0.0] - 2024-04-19
+
+### What's Changed
+* [LM-10468] Added Fundamental Views with Styles by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/1
+* [LM-10468] Added Fundamental Views by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/2
+* [LM-10469] Added Universal Feed and its Styles and Customization by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/3
+* [LM-10470] Added Post Detail Screen and its Styles and Customizations by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/4
+* [LM-10472] Added Notification Feed Screen and its Styles and Customizations by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/5
+* [LM-10471] Added Likes Screen and its Styles and Customizations  by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/6
+* [LM-10471] Added Delete Dialogs and its Styles and Customizations by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/7
+* [LM-10480] Added Edit Post Screen and its Styles and Customizations by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/8
+* [LM-10476] Added Topic Selection Screen and its Styles and Customizations by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/9
+* [LM-10889] Push Notifications by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/10
+* [LM-10902] Analytics by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/11
+* [LM-10858] Community Configurations by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/12
+* [LM-10479] Added Member Tagging Library by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/15
+* [LM-10475] Added Create Post Changes by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/13
+* [LM-10859] Proguard by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/14
+* [LM-11101] Product Signoff Bugs Arch-v2 by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/16
+* Release v1.0.0 by @sidcr7-likeminds in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/17
+
+### New Contributors
+* @ishaan1607 made their first contribution in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/1
+* @sidcr7-likeminds made their first contribution in https://github.com/LikeMindsCommunity/likeminds-feed-android/pull/4
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-android/commits/v1.0.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-android/releases/tag/v1.0.0)


### PR DESCRIPTION
Generated from this repo's GitHub Releases: every published version with its date and release notes, newest first.

Anyone upgrading a published package currently has to read git history or click through the Releases page to find out what changed. This puts it in the repo where people look for it.

Nothing is invented - each entry is the release body as written, with headings demoted one level so they nest under the version. Each entry links back to its release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)